### PR TITLE
Fix small overflow bug in coalescer "hash function".

### DIFF
--- a/elfmalloc/src/slag.rs
+++ b/elfmalloc/src/slag.rs
@@ -857,7 +857,7 @@ impl Coalescer {
             let p_num = p as usize;
             let words = p_num >> 3;
             let pages = words >> 18;
-            pages * words
+            pages.wrapping_mul(words)
         }
         let s = &*Slag::find(item, meta.total_bytes);
         let rc_ptr = &s.rc as *const _ as *mut RefCount;


### PR DESCRIPTION
Running tests without `release` uncovered this issue where we were overflowing a `usize`. The standard wrapping behavior is intended in this case, but we need to explicitly opt into it to avoid UB.