### PR TITLE
mmap-alloc: Support committing and uncommitting on Windows

### DIFF
--- a/mmap-alloc/Cargo.toml
+++ b/mmap-alloc/Cargo.toml
@@ -30,5 +30,5 @@ kernel32-sys = "0.2"
 # use no_std libc
 libc = { version = "0.2", default-features = false }
 object-alloc = "0.1.0"
-sysconf = "0.3.0"
+sysconf = "0.3.1"
 winapi = "0.2"


### PR DESCRIPTION
Generally, this commit drives towards embracing that we expose platform-specific behavior, and chooses to expose that reality rather than trying to present a cross-platform abstraction that will inevitably leak.
- Remove commit on Linux and Mac
- Add commit and uncommit on Windows
- Add the ability to configure whether `alloc` commits