### PR TITLE
malloc-bind: Match exact semantics of the C API

### DIFF
--- a/malloc-bind/CHANGELOG.md
+++ b/malloc-bind/CHANGELOG.md
@@ -12,8 +12,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added this changelog
+- Added `_aligned_malloc` on Windows
+
+### Changed
+- Made `posix_memalign` only compile on Linux and Mac
+- Made `cfree` only compile on Linux
+- Made `valloc` only compile on Linux and Mac
 
 ### Fixed
-- Fixed a bug that prevented compilation on 32-bit Windows
+- Implemented missing logic to better match the semantics of the C allocation
+  API
 - Fixed a bug caused by `sysconf` 0.3.0 that prevented compilation on Windows
   by upgrading to 0.3.1
+- Made it so that the correct lower bound on alignment is used on Windows
+- Set `errno` in more places where it should have been set before

--- a/malloc-bind/README.md
+++ b/malloc-bind/README.md
@@ -9,3 +9,7 @@ malloc-bind
 [![Docs](https://docs.rs/malloc-bind/badge.svg)](https://docs.rs/malloc-bind)
 
 The `malloc-bind` crate provides bindings for the C `malloc` API. Given an implementation of the Rust `Alloc` trait, it produces implementations of the C `malloc` API (`malloc`, `free`, `realloc`, etc) and defines `extern "C"` functions that can be used to produce a C shared object file.
+
+## Platform support
+
+`malloc-bind` currently supports Linux, Mac, and Windows.


### PR DESCRIPTION
This PR contains a number of fixes for bugs and TODOs relating to matching the semantics of the C API (which is made particularly tricky by differing behavior across platforms). It also adds support for the windows `_aligned_malloc` function.

Closes #8.