### PR TITLE
Fix next_multiple for mmap-alloc

### DIFF
--- a/mmap-alloc/CHANGELOG.md
+++ b/mmap-alloc/CHANGELOG.md
@@ -22,3 +22,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a bug that prevented compilation on 32-bit Windows
 - Fixed a bug caused by `sysconf` 0.3.0 that prevented compilation on Windows
   by upgrading to 0.3.1
+- Fixed a bug that failed to round allocations up correctly to the next multiple
+  of the page size

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -430,10 +430,11 @@ unsafe impl UntypedObjectAlloc for MapAlloc {
 }
 
 fn next_multiple(size: usize, unit: usize) -> usize {
-    if size % unit == 0 {
+    let remainder = size % unit;
+    if remainder == 0 {
         size
     } else {
-        size + (size - (size % unit))
+        size + (unit - remainder)
     }
 }
 


### PR DESCRIPTION
The remainder should be subtracted from the unit, not the size: e.g.

```rust
next_multiple(4, 4096); // returns 4
next_multiple(10000, 4096); // returns 18192
```