### PR TITLE
mmap-alloc: Support the full Alloc API

### DIFF
--- a/mmap-alloc/CHANGELOG.md
+++ b/mmap-alloc/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `commit` and `uncommit` methods on Windows
 - Added the ability to configure whether `alloc` commits memory
 - Added documentation about instruction cache incoherency
+- Added support for full Alloc API (`shrink_in_place`, `grow_in_place`, `realloc`)
+    - In Linux, these functions can use `mremap` to grow/shrink beyond the size of a the pagesize
 
 ### Removed
 - Removed `commit` method on on Linux and Mac

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -307,7 +307,7 @@ impl MapAlloc {
         // physical memory.
         let f = |ptr: *mut u8| if ptr.is_null() {
 
-            // First create a mapping that will server as the destination of the remap
+            // First create a mapping that will serve as the destination of the remap
             let new_ptr = map(new_size, self.perms, false, self.huge_pagesize)
                 .expect("Not enough virtual memory to make new mapping");
             debug_assert!(!new_ptr.is_null(),

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -328,8 +328,8 @@ impl MapAlloc {
             if move_size > 0 {
                 let move_result = libc::mremap(
                     allocator.pagesize as *mut _,
-                    size,
-                    size,
+                    move_size,
+                    move_size,
                     libc::MREMAP_MAYMOVE | libc::MREMAP_FIXED,
                     new_ptr.offset(allocator.pagesize as isize)
                 );

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -307,7 +307,8 @@ impl MapAlloc {
         // mremap to return memory starting at null, we have to handle that case. We
         // do this by checking for null, and if we find that map has returned null, we create a
         // new mapping, and mremap all pages after the first into that region. We store the first
-        // byte of the original map (to avoid trying to read data at NULL), and set that byte in
+        // byte of the original map (to avoid trying to read data at NULL,
+        // which is Undefined Behaviour for LLVM), and set that byte in
         // the new mapping. Then memcpy the remainder of the page at NULL.
         // Finally, we tell the OS that the page at NULL is unused, but do not unmap it.
         // Since we leave the page at 0 mapped, future calls should never return null.

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -342,7 +342,7 @@ impl MapAlloc {
 
             *new_ptr = first_byte;
             ptr::copy_nonoverlapping(
-                ptr::null().offset(1),
+                1 as *const _,
                 new_ptr.offset(1),
                 cmp::min(allocator.pagesize - 1, size - 1)
             );

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -468,10 +468,7 @@ unsafe impl<'a> Alloc for &'a MapAlloc {
         if old_size == new_size {
             return Ok(ptr);
         }
-        match self.realloc_helper(ptr, old_size, new_size) {
-            Some(ptr) => Ok(ptr),
-            None => Err(AllocErr::Exhausted { request: new_layout }),
-        }
+        self.realloc_helper(ptr, old_size, new_size).ok_or(AllocErr::Exhausted { request: new_layout })
     }
 
     #[cfg(target_os = "linux")]

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -277,22 +277,28 @@ impl MapAlloc {
         // leaks memory since we never unmap that page, but this isn't a big deal - even if the
         // page is a huge page, since we never write to it, it will remain uncommitted and will
         // thus not consume any physical memory.
-        let f = |ptr: *mut u8| if ptr.is_null() {
-            let unmap_size = size - self.pagesize;
+        #[cold]
+        unsafe fn fix_null(allocator: &MapAlloc, size: usize) -> Option<*mut u8> {
+            let unmap_size = size - allocator.pagesize;
             if unmap_size > 0 {
-                unmap(self.pagesize as *mut u8, unmap_size);
+                unmap(allocator.pagesize as *mut u8, unmap_size);
             }
             // a) Make it more likely that the kernel will not keep the page backed by physical
             // memory and, b) make it so that an access to that range will result in a segfault to
             // make other bugs easier to detect.
             #[cfg(any(target_os = "linux", target_os = "macos"))]
-            mark_unused(ptr::null_mut(), self.pagesize);
-            self.alloc_helper(size)
-        } else {
-            Some(ptr)
-        };
+            mark_unused(ptr::null_mut(), allocator.pagesize);
+            allocator.alloc_helper(size)
+
+        }
         // NOTE: self.commit is guaranteed to be false on Mac.
-        map(size, self.perms, self.commit, self.huge_pagesize).and_then(f)
+        map(size, self.perms, self.commit, self.huge_pagesize).and_then(|ptr| {
+            if ptr.is_null() {
+                fix_null(self, size)
+            } else {
+                Some(ptr)
+            }
+        })
     }
 
     #[cfg(target_os = "linux")]
@@ -305,20 +311,20 @@ impl MapAlloc {
         // Note that this leaks memory since we never unmap that page, but this isn't a big deal -
         // since we never write to it, it will remain uncommitted and will thus not consume any
         // physical memory.
-        let f = |ptr: *mut u8| if ptr.is_null() {
-
+        #[cold]
+        unsafe fn fix_null(allocator: &MapAlloc, size: usize) ->  *mut u8 {
             // First create a mapping that will serve as the destination of the remap
-            let new_ptr = map(new_size, self.perms, false, self.huge_pagesize)
+            let new_ptr = map(size, allocator.perms, false, allocator.huge_pagesize)
                 .expect("Not enough virtual memory to make new mapping");
             debug_assert!(!new_ptr.is_null(),
-                "we have an open mapping on null, new mapping should never be null");
+                          "we have an open mapping on null, new mapping should never be null");
 
             // remap onto the newly-created mapping. This should never fail because the target
             // mapping already exists.
             let move_result = libc::mremap(
                 ptr::null_mut(),
-                new_size,
-                new_size,
+                size,
+                size,
                 libc::MREMAP_MAYMOVE | libc::MREMAP_FIXED,
                 new_ptr
             );
@@ -345,10 +351,15 @@ impl MapAlloc {
                 mark_unused(ptr::null_mut(), pagesize);
             }
             new_ptr
-        } else {
-            ptr
-        };
-        remap(old_ptr, old_size, new_size, false).map(f)
+        }
+
+        remap(old_ptr, old_size, new_size, false).map(|ptr| {
+            if ptr.is_null() {
+                fix_null(self, new_size)
+            } else {
+                ptr
+            }
+        })
     }
 
     /// Commits an existing allocated object.


### PR DESCRIPTION
We implement the `usable_size` function, which allows us to implement
`alloc`/`dealloc`, and get correct implementations of `alloc_excess`,
`grow_in_place`, and `shrink_in_place` for free.

Additionally, for linux, we implement `realloc`, `grow_in_place`, and
`shrink_in_place` using `mremap`.

Fixes #9 

Open Questions:

- When allocating with mmap, we check if mmap returns a null pointer, and handle that case. Currently, this implementation panics if mremap returns a null pointer. Should we handle this case?
    - As far as I can tell, the only way to recover is to to make another mmap, and memcpy (which may not even handle null pointers? we might be really fighting the optimizer no mater what we do), or try to pre-map a page at 0 manually beforehand).
    - Posix specifies [for mmap](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mmap.html), which seems to indicate mmap at least, should never return null (unless we ask for it), and we might want to assume the same applies to mremap?
        > When the implementation selects a value for pa, it never places a mapping at address 0, nor does it replace any extant mapping`