### PR TITLE
Make bsalloc propagate allocation failures from mmap-alloc

### DIFF
--- a/bsalloc/CHANGELOG.md
+++ b/bsalloc/CHANGELOG.md
@@ -15,3 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added this changelog
+
+
+### Changed
+- Changed allocation routines to propagate mmap errors to the user instead of panicking.

--- a/bsalloc/src/lib.rs
+++ b/bsalloc/src/lib.rs
@@ -31,7 +31,7 @@ static GLOBAL: BsAlloc = BsAlloc;
 
 unsafe impl<'a> Alloc for &'a BsAlloc {
     unsafe fn alloc(&mut self, l: Layout) -> Result<*mut u8, AllocErr> {
-        Ok((*ALLOC).alloc(l.size()))
+        (*ALLOC).alloc(l.size())
     }
 
     unsafe fn dealloc(&mut self, item: *mut u8, l: Layout) {


### PR DESCRIPTION
Instead of always `expect`-ing a successful allocation from mmap-alloc,
propagate AllocErrs up to the user. 

Fixes #4