### PR TITLE
object-alloc-test, slab-alloc: Upgrade to interpolate_idents 0.1.8

### DIFF
--- a/object-alloc-test/Cargo.toml
+++ b/object-alloc-test/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/ezrosent/allocators-rs/tree/master/object-alloc
 exclude = ["travis.sh"]
 
 [dependencies]
-interpolate_idents = "0.1"
+interpolate_idents = "0.1.8"
 lazy_static = "0.2.9"
 libc = "0.2"
 object-alloc = "0.1.0"

--- a/object-alloc-test/src/lib.rs
+++ b/object-alloc-test/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(allocator_api)]
 #![feature(test)]
 #![feature(const_fn)]
+#![feature(const_size_of)]
 #![feature(plugin)]
 
 #![plugin(interpolate_idents)]

--- a/slab-alloc/Cargo.toml
+++ b/slab-alloc/Cargo.toml
@@ -39,10 +39,10 @@ hashmap-no-resize = []
 hashmap-no-coalesce = []
 
 [dependencies]
-interpolate_idents = "0.1"
+interpolate_idents = "0.1.8"
 lazy_static = { version = "0.2.9", features = ["spin_no_std"] }
 mmap-alloc = "0.1.0"
 object-alloc = "0.1.0"
-object-alloc-test = "0.1.0"
+object-alloc-test = { path = "../object-alloc-test" }
 rand = "0.3"
 sysconf = "0.3.1"


### PR DESCRIPTION
- Upgrade to `interpolate_idents` 0.1.8
- Add `#![feature(const_size_of)]` to `object-alloc-test`

Closes #91