### PR TITLE
mmap-alloc: Remove huge page support

### DIFF
--- a/mmap-alloc/CHANGELOG.md
+++ b/mmap-alloc/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   and Windows (by using the `VirtualQuery` function)
 
 ### Removed
+- Removed huge page support
 - Removed `commit` method on on Linux and Mac
 - Removed tests for `mmap`s at NULL on Linux and Mac, as it turns out they are
   guaranteed not to happen


### PR DESCRIPTION
Remove huge page support, as huge pages are only supported on Linux and Windows, and do not play nicely with other features we use. For example, on Linux, you can't uncommit (`MADV_DONTNEED`) a mapping created with huge pages, and on Windows, you cannot create a mapping with huge pages without also committing them at the same time.

Closes #50