### PR TITLE
Add alloc-fmt crate for allocation-safe formatting and output

### DIFF
--- a/alloc-fmt/CHANGELOG.md
+++ b/alloc-fmt/CHANGELOG.md
@@ -1,0 +1,14 @@
+<!-- Copyright 2017 the authors. See the 'Copyright and license' section of the
+README.md file at the top-level directory of this repository.
+
+Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+the MIT license (the LICENSE-MIT file) at your option. This file may not be
+copied, modified, or distributed except according to those terms. -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]

--- a/alloc-fmt/Cargo.toml
+++ b/alloc-fmt/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# README.md file at the top-level directory of this repository.
+#
+# Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+# the MIT license (the LICENSE-MIT file) at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+[package]
+name = "alloc-fmt"
+version = "0.1.0"
+authors = ["Joshua Liebow-Feeser <hello@joshlf.com>"]
+license = "Apache-2.0/MIT"
+description = "Formatting utilities safe for use in an allocator."
+
+keywords = ["format", "print", "string", "allocator"]
+categories = ["memory-management", "no-std"]
+
+readme = "README.md"
+documentation = "https://docs.rs/alloc-fmt"
+repository = "https://github.com/ezrosent/allocators-rs/tree/master/alloc-fmt"
+
+exclude = ["appveyor.sh", "travis.sh"]
+
+[dependencies]
+backtrace = "0.3.3"
+libc = "0.2"
+spin = "0.4.6"

--- a/alloc-fmt/README.md
+++ b/alloc-fmt/README.md
@@ -1,0 +1,16 @@
+<!-- Copyright 2017 the authors. See the 'Copyright and license' section of the
+README.md file at the top-level directory of this repository.
+
+Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+the MIT license (the LICENSE-MIT file) at your option. This file may not be
+copied, modified, or distributed except according to those terms. -->
+
+alloc-fmt
+=========
+
+`alloc-fmt` provides formatting and assertion macros similar to `println`,
+`eprintln`,  `assert`, `debug_assert`, etc which are safe for use in a global
+allocator. The standard library's formatting  and assertion macros can allocate,
+meaning that if they are used in the implementation of a global allocator, it
+can cause infinite recursion. The macros in this crate do not allocate in order
+to avoid this problem.

--- a/alloc-fmt/appveyor.sh
+++ b/alloc-fmt/appveyor.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# README.md file at the top-level directory of this repository.
+#
+# Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+# the MIT license (the LICENSE-MIT file) at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+set -x
+set -e
+
+if [ "$RUST_NIGHTLY" != "1" ]; then
+  exit 0
+fi
+
+cargo build
+RUST_BACKTRACE=1 cargo test
+RUST_BACKTRACE=1 cargo run -- --bin print

--- a/alloc-fmt/src/bin/assert.rs
+++ b/alloc-fmt/src/bin/assert.rs
@@ -1,0 +1,36 @@
+// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// README.md file at the top-level directory of this repository.
+//
+// Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+// the MIT license (the LICENSE-MIT file) at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate alloc_fmt;
+
+#[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+fn main() {
+    let arg = std::env::args().nth(1).expect("must provide an argument");
+
+    match arg.as_str() {
+        "assert" => alloc_assert!(false && true),
+        "assert_fmt" => alloc_assert!(false && true, "foo"),
+        "assert_fmt_args" => alloc_assert!(false && true, "foo: {}", "bar"),
+        "debug_assert" => alloc_debug_assert!(false && true),
+        "debug_assert_fmt" => alloc_debug_assert!(false && true, "foo"),
+        "debug_assert_fmt_args" => alloc_debug_assert!(false && true, "foo: {}", "bar"),
+        "assert_eq" => alloc_assert_eq!(1 + 2, 1),
+        "assert_eq_fmt" => alloc_assert_eq!(1 + 2, 1, "foo"),
+        "assert_eq_fmt_args" => alloc_assert_eq!(1 + 2, 1, "foo: {}", "bar"),
+        "debug_assert_eq" => alloc_debug_assert_eq!(1 + 2, 1),
+        "debug_assert_eq_fmt" => alloc_debug_assert_eq!(1 + 2, 1, "foo"),
+        "debug_assert_eq_fmt_args" => alloc_debug_assert_eq!(1 + 2, 1, "foo: {}", "bar"),
+        "assert_ne" => alloc_assert_ne!(1 + 2, 3),
+        "assert_ne_fmt" => alloc_assert_ne!(1 + 2, 3, "foo"),
+        "assert_ne_fmt_args" => alloc_assert_ne!(1 + 2, 3, "foo: {}", "bar"),
+        "debug_assert_ne" => alloc_debug_assert_ne!(1 + 2, 3),
+        "debug_assert_ne_fmt" => alloc_debug_assert_ne!(1 + 2, 3, "foo"),
+        "debug_assert_ne_fmt_args" => alloc_debug_assert_ne!(1 + 2, 3, "foo: {}", "bar"),
+        _ => eprintln!("see source code for available arguments"),
+    }
+}

--- a/alloc-fmt/src/bin/print.rs
+++ b/alloc-fmt/src/bin/print.rs
@@ -1,0 +1,16 @@
+// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// README.md file at the top-level directory of this repository.
+//
+// Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+// the MIT license (the LICENSE-MIT file) at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate alloc_fmt;
+
+fn main() {
+    alloc_print!("alloc_print\n");
+    alloc_println!("alloc_println");
+    alloc_eprint!("alloc_eprint\n");
+    alloc_eprintln!("alloc_eprintln");
+}

--- a/alloc-fmt/src/lib.rs
+++ b/alloc-fmt/src/lib.rs
@@ -1,0 +1,347 @@
+// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// README.md file at the top-level directory of this repository.
+//
+// Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+// the MIT license (the LICENSE-MIT file) at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Allocator-safe formatting and assertion macros.
+//!
+//! `alloc-fmt` provides formatting and assertion macros similar to the standard library's
+//! `println`, `eprintln`, `assert`, `debug_assert`, etc which are safe for use in a global
+//! allocator. The standard library's formatting and assertion macros can allocate, meaning that if
+//! they are used in the implementation of a global allocator, it can cause infinite recursion. The
+//! macros in this crate avoid this problem by either not allocating (in the case of formatting
+//! macros) or detecting recursion (in the case of assertion macros).
+//!
+//! # Usage and Behavior
+//! The macros in this crate are named `alloc_xxx`, where `xxx` is the name of the equivalent
+//! standard library macro (e.g., `alloc_println`, `alloc_debug_assert`, etc).
+//!
+//! The behavior of the formatting macros is identical to the behavior of their standard library
+//! counterparts. The behavior of the assertion macros is somewhat different. When an assertion
+//! fails, a message is first unconditionally printed to stderr (in case further processing causes
+//! a crash). A stack trace is then printed, and the process aborts. If recursion is detected
+//! during the printing of the stack trace, the process immediately aborts. Recusion can happen if,
+//! for example, the code that computes the stack trace allocates, triggering further assertion
+//! failures. This check is conservative - it may sometimes detect recursion when there is none.
+//!
+//! Unlike the standard library assertion macros, no panic is generated, and once an assertion
+//! failure triggers, it cannot be caught or aborted.
+
+#![no_std]
+#![feature(core_intrinsics)]
+
+extern crate backtrace;
+extern crate libc;
+extern crate spin;
+
+use core::fmt::*;
+use core::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
+
+// Import items that macros need to reference. They will reference them as $crate::foo instead of
+// core::foo since core isn't guaranteed to be imported in the user's scope.
+#[doc(hidden)]
+pub use core::mem::drop;
+#[doc(hidden)]
+pub use core::fmt::Write;
+#[doc(hidden)]
+pub use core::sync::atomic::Ordering::SeqCst;
+
+#[doc(hidden)]
+pub static STDERR_MTX: spin::Mutex<()> = spin::Mutex::new(());
+#[doc(hidden)]
+pub static STDOUT_MTX: spin::Mutex<()> = spin::Mutex::new(());
+
+#[doc(hidden)]
+pub static STDOUT: libc::c_int = 1;
+#[doc(hidden)]
+pub static STDERR: libc::c_int = 2;
+
+#[doc(hidden)]
+pub struct FDWriter(pub libc::c_int);
+
+impl Write for FDWriter {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> Result {
+        let mut buf = s.as_bytes();
+        while !buf.is_empty() {
+            unsafe {
+                let written = libc::write(self.0, buf.as_ptr() as *const _, buf.len());
+                if written < 1 {
+                    core::intrinsics::abort();
+                }
+                buf = &buf[written as usize..];
+            }
+        }
+        Ok(())
+    }
+}
+
+// We can't simply 'pub use core::intrinsics::abort' because its use requires
+// feature(core_intrinsics), which the user would have to enable.
+#[doc(hidden)]
+pub unsafe fn abort() -> ! {
+    core::intrinsics::abort();
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! print_internal {
+    ($file:expr, $mtx:expr, $($arg:tt)*) => {
+        // in case we're called from inside an unsafe block
+        #[allow(unused_unsafe)]
+        unsafe {
+            let guard = $mtx.lock();
+
+            let mut fd = $crate::FDWriter($file);
+            use $crate::Write;
+            let _ = write!(&mut fd, $($arg)*).map_err(|_| {
+                $crate::abort();
+            });
+
+            // explicitly drop the guard so we're guaranteed it lives at least this long;
+            // since we don't actually use the guard, the compiler could theoretically
+            // drop it sooner.
+            $crate::drop(guard);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_print {
+    ($($arg:tt)*) => (print_internal!($crate::STDOUT, $crate::STDOUT_MTX, $($arg)*))
+}
+
+#[macro_export]
+macro_rules! alloc_eprint {
+    ($($arg:tt)*) => (print_internal!($crate::STDERR, $crate::STDERR_MTX, $($arg)*))
+}
+
+#[macro_export]
+macro_rules! alloc_println {
+    () => (alloc_print!("\n"));
+    ($fmt:expr) => (alloc_print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (alloc_print!(concat!($fmt, "\n"), $($arg)*));
+}
+
+#[macro_export]
+macro_rules! alloc_eprintln {
+    () => (alloc_eprint!("\n"));
+    ($fmt:expr) => (alloc_eprint!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (alloc_eprint!(concat!($fmt, "\n"), $($arg)*));
+}
+
+// Sometimes backtraces allocate. If that allocation causes an assertion failure, then we can get
+// into an infinite recursion scenario. In order to detect this, we set this global bool to true,
+// and load it before printing a backtrace. If we find that it is true, we immediately abort
+// (essentially short-circuiting what would eventually happen if print_backtrace_and_abort
+// successfully finished executing).
+#[doc(hidden)]
+pub static IS_ASSERTING: AtomicBool = ATOMIC_BOOL_INIT;
+
+#[macro_export]
+macro_rules! alloc_assert {
+    ($pred:expr) => {
+        // Do this instead of alloc_assert!($pred, stringify!($pred)) in case $pred contains
+        // characters that would be interpreted as formatting directives.
+        alloc_assert!($pred, "{}", stringify!($pred));
+    };
+    ($pred:expr, $fmt:expr) => {
+        if !($pred) {
+            // in case we're called from inside an unsafe block
+            #[allow(unused_unsafe)]
+            unsafe {
+                alloc_eprintln!(concat!("assertion failed: ", $fmt, ", {}:{}:{}"), file!(), line!(), column!());
+
+                if $crate::IS_ASSERTING.compare_and_swap(false, true, $crate::SeqCst) {
+                    // compare_and_swap returns the old value; true means somebody's already asserting.
+                    alloc_eprintln!("assertion failed while aborting");
+                    $crate::abort();
+                }
+
+                $crate::print_backtrace_and_abort();
+            }
+        }
+    };
+    ($pred:expr, $fmt:expr, $($arg:tt)*) => {
+        if !($pred) {
+            // in case we're called from inside an unsafe block
+            #[allow(unused_unsafe)]
+            unsafe {
+                // If we wanted to do this in a single line, we'd have two options:
+                //   eprintln!(concat!("assertion failed: ", $fmt, ", {}:{}:{}"), $($arg)*, file!(), line!(), column!());
+                //   eprintln!(concat!("assertion failed: ", $fmt, ", {}:{}:{}"), $($arg)* file!(), line!(), column!());
+                // (the latter without a comma after $($arg)*). The first one breaks on invocations
+                // like:
+                //   alloc_assert!(
+                //       foo,
+                //       "bar: {}",
+                //       baz,
+                //   );
+                // While the second one breaks on invocations like:
+                //   alloc_assert!(foo, "bar: {}", baz);
+                // Thus, we just do it this (slightly less efficient) way.
+                alloc_eprint!(concat!("assertion failed: ", $fmt), $($arg)*);
+                alloc_eprintln!(", {}:{}:{}", file!(), line!(), column!());
+
+                if $crate::IS_ASSERTING.compare_and_swap(false, true, $crate::SeqCst) {
+                    // compare_and_swap returns the old value; true means somebody's already asserting.
+                    alloc_eprintln!("assertion failed while aborting");
+                    $crate::abort();
+                }
+
+                $crate::print_backtrace_and_abort();
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_debug_assert {
+    ($($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            alloc_assert!($($arg)*);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_assert_eq {
+    ($a:expr, $b:expr) => {
+        {
+            let a = $a;
+            let b = $b;
+            let s = stringify!($a == $b);
+            alloc_assert!(a == b, "{} (evaluated to {:?} == {:?})", s, a, b);
+        }
+    };
+    ($a:expr, $b:expr, $fmt:expr) => {
+        {
+            let a = $a;
+            let b = $b;
+            let s = stringify!($a == $b);
+            alloc_assert!(a == b, concat!("{} (evaluated to {:?} == {:?}): ", $fmt), s, a, b);
+        }
+    };
+    ($a:expr, $b:expr, $fmt:expr, $($arg:tt)*) => {
+        {
+            let a = $a;
+            let b = $b;
+            let s = stringify!($a == $b);
+            alloc_assert!(a == b, concat!("{} (evaluated to {:?} == {:?}): ", $fmt), s, a, b, $($arg)*);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_debug_assert_eq {
+    ($($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            alloc_assert_eq!($($arg)*);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_assert_ne {
+    ($a:expr, $b:expr) => {
+        {
+            let a = $a;
+            let b = $b;
+            let s = stringify!($a != $b);
+            alloc_assert!(a != b, "{} (evaluated to {:?} != {:?})", s, a, b);
+        }
+    };
+    ($a:expr, $b:expr, $fmt:expr) => {
+        {
+            let a = $a;
+            let b = $b;
+            let s = stringify!($a != $b);
+            alloc_assert!(a != b, concat!("{} (evaluated to {:?} != {:?}): ", $fmt), s, a, b);
+        }
+    };
+    ($a:expr, $b:expr, $fmt:expr, $($arg:tt)*) => {
+        {
+            let a = $a;
+            let b = $b;
+            let s = stringify!($a != $b);
+            alloc_assert!(a != b, concat!("{} (evaluated to {:?} != {:?}): ", $fmt), s, a, b, $($arg)*);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_debug_assert_ne {
+    ($($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            alloc_assert_ne!($($arg)*);
+        }
+    }
+}
+
+/// Print a backtrace and then abort the process.
+///
+/// `print_backtrace_and_abort` should be called after any relevant output has been flushed to
+/// stderr so that even if this function crashes (since the `backtrace` crate does not guarantee
+/// allocation-free backtraces), as much information as possible has already been output.
+#[doc(hidden)]
+pub unsafe fn print_backtrace_and_abort() -> ! {
+    // TODO(joshlf): Currently, this function prints itself and its callees in the trace. We should
+    // figure out a way to omit those and have the first printed frame be the caller's.
+
+    backtrace::trace(|frame| {
+        let ip = frame.ip();
+        backtrace::resolve(ip, |symbol| {
+            if let Some(name) = symbol.name() {
+                alloc_eprintln!("{}", name);
+            } else {
+                alloc_eprintln!("<unknown function>");
+            }
+            if let Some(path) = symbol.filename() {
+                if let Some(s) = path.to_str() {
+                    alloc_eprint!("\t{}", s);
+                } else {
+                    alloc_eprint!("\t<unknown file>");
+                }
+            } else {
+                alloc_eprint!("\t<unknown file>");
+            }
+            if let Some(line) = symbol.lineno() {
+                alloc_eprintln!(":{}", line);
+            } else {
+                alloc_eprintln!();
+            }
+        });
+        true
+    });
+    core::intrinsics::abort();
+}
+
+// Test the macros by expanding them here and ensuring that they compile properly.
+#[allow(unused)]
+#[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+fn never_called() {
+    alloc_print!("foo");
+    alloc_println!("foo");
+    alloc_eprint!("foo");
+    alloc_eprintln!("foo");
+    alloc_assert!(false && true);
+    alloc_assert!(false && true, "foo");
+    alloc_assert!(false && true, "foo: {}", "bar");
+    alloc_debug_assert!(false && true);
+    alloc_debug_assert!(false && true, "foo");
+    alloc_debug_assert!(false && true, "foo: {}", "bar");
+    alloc_assert_eq!(1 + 2, 1);
+    alloc_assert_eq!(1 + 2, 1, "foo");
+    alloc_assert_eq!(1 + 2, 1, "foo: {}", "bar");
+    alloc_debug_assert_eq!(1 + 2, 1);
+    alloc_debug_assert_eq!(1 + 2, 1, "foo");
+    alloc_debug_assert_eq!(1 + 2, 1, "foo: {}", "bar");
+    alloc_assert_eq!(1 + 2, 3);
+    alloc_assert_eq!(1 + 2, 3, "foo");
+    alloc_assert_eq!(1 + 2, 3, "foo: {}", "bar");
+    alloc_debug_assert_eq!(1 + 2, 3);
+    alloc_debug_assert_eq!(1 + 2, 3, "foo");
+    alloc_debug_assert_eq!(1 + 2, 3, "foo: {}", "bar");
+}

--- a/alloc-fmt/travis.sh
+++ b/alloc-fmt/travis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# README.md file at the top-level directory of this repository.
+#
+# Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
+# the MIT license (the LICENSE-MIT file) at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+set -x
+set -e
+
+travis-cargo --only nightly build
+RUST_BACKTRACE=1 travis-cargo --only nightly test
+RUST_BACKTRACE=1 travis-cargo --only nightly run -- --bin print

--- a/bsalloc/Cargo.toml
+++ b/bsalloc/Cargo.toml
@@ -21,11 +21,7 @@ repository = "https://github.com/ezrosent/allocators-rs/tree/master/bsalloc"
 
 exclude = ["appveyor.sh", "travis.sh"]
 
-[profile.dev]
-panic = "abort"
-[profile.release]
-panic = "abort"
-
 [dependencies]
+alloc-fmt = { path = "../alloc-fmt" }
 lazy_static = { version = "0.2.9", features = ["spin_no_std"] }
 mmap-alloc = { path = "../mmap-alloc" }

--- a/bsalloc/src/lib.rs
+++ b/bsalloc/src/lib.rs
@@ -11,6 +11,8 @@
 #![feature(global_allocator)]
 extern crate alloc;
 #[macro_use]
+extern crate alloc_fmt;
+#[macro_use]
 extern crate lazy_static;
 extern crate mmap_alloc;
 mod bsalloc;
@@ -23,7 +25,7 @@ use core::ptr;
 fn assert_nonoverlapping(r1: (usize, usize), r2: (usize, usize)) {
     let (_, b) = cmp::min(r1, r2);
     let (c, _) = cmp::max(r1, r2);
-    assert!(c >= b);
+    alloc_assert!(c >= b);
 }
 
 #[global_allocator]

--- a/elfmalloc/Cargo.toml
+++ b/elfmalloc/Cargo.toml
@@ -44,6 +44,7 @@ magazine_layer = []
 c-api = ["nightly"]
 
 [dependencies]
+alloc-fmt = { path = "../alloc-fmt" }
 bagpipe = { path = "../bagpipe" }
 bsalloc = "0.1.0"
 lazy_static = "0.2.9"

--- a/elfmalloc/src/alloc_impl.rs
+++ b/elfmalloc/src/alloc_impl.rs
@@ -58,7 +58,7 @@ unsafe impl<'a> Alloc for &'a ElfMallocGlobal {
 unsafe impl Malloc for ElfMallocGlobal {
     unsafe fn c_malloc(&self, size: size_t) -> *mut c_void {
         let p = global::alloc(size as usize) as *mut c_void;
-        debug_assert_eq!((p as usize) % MIN_ALIGN,
+        alloc_debug_assert_eq!((p as usize) % MIN_ALIGN,
                          0,
                          "object does not have the required alignment of {}: {:?}",
                          MIN_ALIGN,
@@ -66,7 +66,7 @@ unsafe impl Malloc for ElfMallocGlobal {
         p
     }
     unsafe fn c_free(&self, p: *mut c_void) {
-        debug_assert_eq!((p as usize) % MIN_ALIGN,
+        alloc_debug_assert_eq!((p as usize) % MIN_ALIGN,
                          0,
                          "object does not have the required alignment of {}: {:?}",
                          MIN_ALIGN,
@@ -77,7 +77,7 @@ unsafe impl Malloc for ElfMallocGlobal {
         global::free(p as *mut u8)
     }
     unsafe fn c_realloc(&self, p: *mut c_void, new_size: size_t) -> *mut c_void {
-        debug_assert_eq!((p as usize) % MIN_ALIGN,
+        alloc_debug_assert_eq!((p as usize) % MIN_ALIGN,
                          0,
                          "object does not have the required alignment of {}: {:?}",
                          MIN_ALIGN,

--- a/elfmalloc/src/lib.rs
+++ b/elfmalloc/src/lib.rs
@@ -18,6 +18,8 @@ extern crate alloc;
 extern crate bagpipe;
 extern crate num_cpus;
 
+#[macro_use]
+extern crate alloc_fmt;
 // Linking in `bsalloc` causes it to be used as the global heap allocator. That is important when
 // using this as a basis for a `malloc` library, but it becomes a hindrance when using this crate
 // as a specialized allocator library.

--- a/elfmalloc/src/rust_alloc.rs
+++ b/elfmalloc/src/rust_alloc.rs
@@ -168,8 +168,8 @@ impl<M: MemorySource> PageFrontend<M> {
         pipe_size: usize,
         parent: PageSource<M>,
     ) -> PageFrontend<M> {
-        debug_assert!(size <= parent.source.page_size());
-        debug_assert!(size.is_power_of_two());
+        alloc_debug_assert!(size <= parent.source.page_size());
+        alloc_debug_assert!(size.is_power_of_two());
         PageFrontend {
             parent: parent,
             pages: SlagPipe::new_size_cleanup(pipe_size, PageCleanup::new(size)),
@@ -400,7 +400,7 @@ impl ElfMallocBuilder {
     pub fn build<M: MemorySource>(&self) -> ElfMalloc<M> {
         let pa = PageAlloc::<M>::new(self.page_size, self.target_pa_size, self.large_pipe_size, AllocType::SmallSlag);
         let n_small_classes = (self.page_size / 4) / MULTIPLE;
-        assert!(n_small_classes > 0);
+        alloc_assert!(n_small_classes > 0);
         let mut meta_pointers = mmap::map(mem::size_of::<Metadata>() * n_small_classes) as
             *mut Metadata;
         let small_classes = Multiples::init(MULTIPLE, n_small_classes, |size: usize| {
@@ -449,7 +449,7 @@ impl ElfMallocBuilder {
                 (size, target_size, self.small_pipe_size, p_source.clone()),
             )
         });
-        debug_assert!(small_classes.max_key().is_power_of_two());
+        alloc_debug_assert!(small_classes.max_key().is_power_of_two());
         ElfMalloc {
             small: small_classes,
             large: large_classes,

--- a/elfmalloc/src/sources.rs
+++ b/elfmalloc/src/sources.rs
@@ -72,7 +72,7 @@ impl MemorySource for MmapSource {
         mmap::fallible_map(req_size).and_then(|mem| {
             let mem_num = mem as usize;
 
-            debug_assert_eq!(mod_size(mem_num, system_page_size), 0);
+            alloc_debug_assert_eq!(mod_size(mem_num, system_page_size), 0);
 
             // region at the end that is not needed.
             let rem1 = mod_size(mem_num, self.page_size);
@@ -80,7 +80,7 @@ impl MemorySource for MmapSource {
             let rem2 = self.page_size - rem1;
             unsafe {
                 let res = mem.offset(rem2 as isize);
-                debug_assert_eq!(mod_size(res as usize, self.page_size), 0);
+                alloc_debug_assert_eq!(mod_size(res as usize, self.page_size), 0);
                 if rem1 > 0 {
                     mmap::unmap(res.offset(target_size as isize), rem1);
                 }
@@ -140,7 +140,7 @@ macro_rules! check_bump {
         #[cfg(debug_assertions)]
         {
             let bump = $slf.bump.load(Ordering::Relaxed);
-            debug_assert!(!bump.is_null());
+            alloc_debug_assert!(!bump.is_null());
         }
     };
 }
@@ -188,8 +188,8 @@ impl MemorySource for Creek {
             panic!("unable to map heap")
         };
         // lots of stuff breaks if this isn't true
-        assert!(page_size.is_power_of_two());
-        assert!(page_size > mem::size_of::<usize>());
+        alloc_assert!(page_size.is_power_of_two());
+        alloc_assert!(page_size > mem::size_of::<usize>());
         // first, let's grab some memory;
         let (orig_base, heap_size) = get_heap();
         info!("created heap of size {}", heap_size);
@@ -234,7 +234,7 @@ impl MemoryBlock for Creek {
 impl Clone for Creek {
     fn clone(&self) -> Self {
         let bump = self.bump.load(Ordering::Relaxed);
-        debug_assert!(!bump.is_null());
+        alloc_debug_assert!(!bump.is_null());
         Creek {
             page_size: self.page_size,
             map_info: self.map_info.clone(),

--- a/elfmalloc/src/utils.rs
+++ b/elfmalloc/src/utils.rs
@@ -251,10 +251,10 @@ mod tests {
     fn basic_functionality() {
         let mut l = Lazy::<DefaultInit<usize>>::new(());
         let l_u = l.0;
-        assert_eq!(l_u, 0);
+        alloc_assert_eq!(l_u, 0);
         *l = DefaultInit(1);
         let l_u = l.0;
-        assert_eq!(l_u, 1);
+        alloc_assert_eq!(l_u, 1);
     }
 
 }

--- a/elfmalloc/src/vec_alloc.rs
+++ b/elfmalloc/src/vec_alloc.rs
@@ -195,14 +195,14 @@ forward_slice_index_impl!(ops::RangeFull, [T]);
 impl<T, A: Alloc> ops::Index<usize> for AVec<T, A> {
     type Output = T;
     fn index(&self, ix: usize) -> &T {
-        assert!(ix < self.len);
+        alloc_assert!(ix < self.len);
         unsafe { &*self.get_raw(ix) }
     }
 }
 
 impl<T, A: Alloc> ops::IndexMut<usize> for AVec<T, A> {
     fn index_mut(&mut self, ix: usize) -> &mut T {
-        assert!(ix < self.len);
+        alloc_assert!(ix < self.len);
         unsafe { &mut *self.get_raw(ix) }
     }
 }
@@ -254,7 +254,7 @@ mod tests {
             rv.push(i);
         }
         let expect: Vec<_> = (0..1000).collect();
-        assert_eq!(&*rv, &expect[..]);
+        alloc_assert_eq!(&*rv, &expect[..]);
     }
 
     #[test]
@@ -268,7 +268,7 @@ mod tests {
         rv.push(!0);
         let mut expect: Vec<_> = (0..999).collect();
         expect.push(!0);
-        assert_eq!(&*rv, &expect[..]);
+        alloc_assert_eq!(&*rv, &expect[..]);
     }
 
     #[test]
@@ -282,7 +282,7 @@ mod tests {
         let tmp = expect.clone();
         expect.extend(&*rv);
         rv.extend(tmp.into_iter());
-        assert_eq!(&*rv, &expect[..]);
+        alloc_assert_eq!(&*rv, &expect[..]);
     }
 
     #[bench]


### PR DESCRIPTION
This new `alloc-fmt` crate provides formatting macros equivalent to the standard library's macros, except they don't allocate. I had long suspected that this might be an issue, but I finally came across a bug in PR #85 that is caused by this problem, so I figured it was finally time to address the it.