### PR TITLE
Malloc bind unlikely

### DIFF
--- a/malloc-bind/CHANGELOG.md
+++ b/malloc-bind/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   allocation API
 
 ### Changed
+- Put some `unlikely` in `if`s
 - Made `cfree` only compile on Linux
 - Made `posix_memalign` and `valloc` only compile on Linux and Mac
 - Made `LayoutFinder` and its methods unsafe


### PR DESCRIPTION
This PR is a possible solution for #111. Actually, I hadn't found use cases for "likely", so I've put "unlikely" only.

I've put "unlikely" to "unhappy" paths, like NULL on free() and erroneous arguments in "posix_memalign". The motivation behind the second example is that the code not checking its arguments beforehand may be punished in terms of performance.