### PR TITLE
103 fix

### DIFF
--- a/alloc-fmt/src/lib.rs
+++ b/alloc-fmt/src/lib.rs
@@ -68,7 +68,10 @@ impl Write for FDWriter {
         let mut buf = s.as_bytes();
         while !buf.is_empty() {
             unsafe {
+                #[cfg(not(target_os = "windows"))]
                 let written = libc::write(self.0, buf.as_ptr() as *const _, buf.len());
+                #[cfg(target_os = "windows")]
+                let written = libc::write(self.0, buf.as_ptr() as *const _, buf.len() as libc::c_uint);
                 if written < 1 {
                     core::intrinsics::abort();
                 }

--- a/bsalloc/src/bsalloc.rs
+++ b/bsalloc/src/bsalloc.rs
@@ -9,7 +9,7 @@ use super::core::sync::atomic::{AtomicPtr, Ordering};
 use super::core::mem;
 use super::core::ptr;
 
-use super::mmap_alloc::{MapAlloc, MapAllocBuilder};
+use super::mmap_alloc::MapAlloc
 use super::{Alloc, Layout, AllocErr};
 
 #[derive(Copy, Clone)]
@@ -22,7 +22,7 @@ lazy_static! {
 pub struct GlobalAllocator {
     small_objs: large::Cache,
     large_objs: small::Cache,
-    ma: MapAlloc::default(),
+    ma: MapAlloc,
 }
 
 impl GlobalAllocator {
@@ -30,7 +30,7 @@ impl GlobalAllocator {
         GlobalAllocator {
             small_objs: large::Cache::new(1 << 10),
             large_objs: small::Cache::new(18 << 10),
-            ma: MapAllocBuilder::default().commit(true).build()
+            ma: MapAlloc::default()
         }
     }
 

--- a/bsalloc/src/bsalloc.rs
+++ b/bsalloc/src/bsalloc.rs
@@ -9,7 +9,7 @@ use super::core::sync::atomic::{AtomicPtr, Ordering};
 use super::core::mem;
 use super::core::ptr;
 
-use super::mmap_alloc::MapAlloc;
+use super::mmap_alloc::{MapAlloc, MapAllocBuilder};
 use super::{Alloc, Layout, AllocErr};
 
 #[derive(Copy, Clone)]
@@ -30,7 +30,7 @@ impl GlobalAllocator {
         GlobalAllocator {
             small_objs: large::Cache::new(1 << 10),
             large_objs: small::Cache::new(18 << 10),
-            ma: MapAlloc::default(),
+            ma: MapAllocBuilder::default().commit(true).build()
         }
     }
 

--- a/bsalloc/src/bsalloc.rs
+++ b/bsalloc/src/bsalloc.rs
@@ -22,7 +22,7 @@ lazy_static! {
 pub struct GlobalAllocator {
     small_objs: large::Cache,
     large_objs: small::Cache,
-    ma: MapAlloc,
+    ma: MapAlloc::default(),
 }
 
 impl GlobalAllocator {

--- a/bsalloc/src/bsalloc.rs
+++ b/bsalloc/src/bsalloc.rs
@@ -9,7 +9,7 @@ use super::core::sync::atomic::{AtomicPtr, Ordering};
 use super::core::mem;
 use super::core::ptr;
 
-use super::mmap_alloc::MapAlloc
+use super::mmap_alloc::MapAlloc;
 use super::{Alloc, Layout, AllocErr};
 
 #[derive(Copy, Clone)]
@@ -22,7 +22,7 @@ lazy_static! {
 pub struct GlobalAllocator {
     small_objs: large::Cache,
     large_objs: small::Cache,
-    ma: MapAlloc,
+    ma: MapAlloc
 }
 
 impl GlobalAllocator {


### PR DESCRIPTION
Simple fix to segfault when using bsalloc on windows.
However on my system build fails because libc::write (used in alloc-fmt) expects a u32 as its last argument instead of a usize, however CI fails if I attempt to correct this.  I would like to confirm if this is a windows-specific issue and should be addressed in its own issue.