### PR TITLE
mmap-alloc: Re-enable Travis tests on Mac

### DIFF
--- a/mmap-alloc/travis.sh
+++ b/mmap-alloc/travis.sh
@@ -13,6 +13,4 @@ set -e
 export RUST_TEST_THREADS=1
 
 travis-cargo --only nightly build
-# TODO: Figure out why tests cause SIGBUS on Mac (see issue #120)
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then exit 0; fi
 RUST_BACKTRACE=1 travis-cargo --only nightly test


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/45866 has landed in nightly, re-enable tests to see if they work now.