### PR TITLE
Cargo.toml : upgrade lazy-static to 1.0.0

### DIFF
--- a/bsalloc/Cargo.toml
+++ b/bsalloc/Cargo.toml
@@ -23,5 +23,5 @@ exclude = ["appveyor.sh", "travis.sh"]
 
 [dependencies]
 alloc-fmt = { path = "../alloc-fmt" }
-lazy_static = { version = "0.2.9", features = ["spin_no_std"] }
+lazy_static = { version = "1.0.0", features = ["spin_no_std"] }
 mmap-alloc = { path = "../mmap-alloc" }

--- a/elfmalloc/Cargo.toml
+++ b/elfmalloc/Cargo.toml
@@ -49,7 +49,7 @@ alloc-fmt = { path = "../alloc-fmt" }
 alloc-tls = { path = "../alloc-tls" }
 bagpipe = { path = "../bagpipe" }
 bsalloc = "0.1.0"
-lazy_static = "0.2.9"
+lazy_static = "1.0.0"
 libc = "0.2"
 log = "0.3.8"
 malloc-bind = { path = "../malloc-bind" }

--- a/malloc-bind/Cargo.toml
+++ b/malloc-bind/Cargo.toml
@@ -23,6 +23,6 @@ exclude = ["appveyor.sh", "travis.sh"]
 
 [dependencies]
 errno = "0.2"
-lazy_static = { version = "0.2.9", features = ["spin_no_std"] }
+lazy_static = { version = "1.0.0", features = ["spin_no_std"] }
 libc = "0.2"
 sysconf = "0.3.1"

--- a/object-alloc-test/Cargo.toml
+++ b/object-alloc-test/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["appveyor.sh", "travis.sh"]
 
 [dependencies]
 interpolate_idents = "0.1.8"
-lazy_static = "0.2.9"
+lazy_static = "1.0.0"
 libc = "0.2"
 object-alloc = "0.1.0"
 quickcheck = "0.4"

--- a/slab-alloc/Cargo.toml
+++ b/slab-alloc/Cargo.toml
@@ -40,7 +40,7 @@ hashmap-no-coalesce = []
 
 [dependencies]
 interpolate_idents = "0.1.8"
-lazy_static = { version = "0.2.9", features = ["spin_no_std"] }
+lazy_static = { version = "1.0.0", features = ["spin_no_std"] }
 mmap-alloc = "0.1.0"
 object-alloc = "0.1.0"
 object-alloc-test = { path = "../object-alloc-test" }


### PR DESCRIPTION
Hey

Upgraded lazy-static to 1.0.0. I have run the test suites of each sub-repository where the change has been made there is no breaking change in switch from 0.2.9 to 1.0.0. 

Fixes #138 