### PR TITLE
object-alloc: Switch from *mut to NonNull

### DIFF
--- a/mmap-alloc/CHANGELOG.md
+++ b/mmap-alloc/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- Upgraded to new `UntypedObjectAlloc` trait that uses `NonNull<u8>` instead
+  of `*mut u8`
+
 ## 0.2.0
 
 ### Added

--- a/mmap-alloc/Cargo.toml
+++ b/mmap-alloc/Cargo.toml
@@ -26,6 +26,6 @@ errno = "0.2"
 kernel32-sys = "0.2"
 # use no_std libc
 libc = { version = "0.2", default-features = false }
-object-alloc = "0.1.0"
+object-alloc = { path = "../object-alloc" }
 sysconf = "0.3.1"
 winapi = "0.2"

--- a/object-alloc-test/CHANGELOG.md
+++ b/object-alloc-test/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2017 the authors. See the 'Copyright and license' section of the
+<!-- Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 README.md file at the top-level directory of this repository.
 
 Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -15,3 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added this changelog
+
+### Changed
+- Upgraded to new `ObjectAlloc` trait that uses `NonNull<u8>` instead
+  of `*mut u8`

--- a/object-alloc-test/Cargo.toml
+++ b/object-alloc-test/Cargo.toml
@@ -23,10 +23,14 @@ exclude = ["appveyor.sh", "travis.sh"]
 
 [dependencies]
 interpolate_idents = "0.2.2"
+kernel32-sys = "0.2"
 lazy_static = "1.0.0"
 libc = "0.2"
-object-alloc = "0.1.0"
+object-alloc = { path = "../object-alloc" }
 quickcheck = "0.4"
 rand = "0.3"
 twox-hash = "1.1"
-winapi = "0.2"
+
+[dependencies.winapi]
+version = "0.3"
+features = ["basetsd", "psapi"]

--- a/object-alloc-test/src/lib.rs
+++ b/object-alloc-test/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 // README.md file at the top-level directory of this repository.
 //
 // Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -10,6 +10,7 @@
 #![feature(test)]
 #![feature(const_fn)]
 #![feature(const_size_of)]
+#![feature(nonnull_cast)]
 #![feature(plugin)]
 
 #![plugin(interpolate_idents)]

--- a/object-alloc/CHANGELOG.md
+++ b/object-alloc/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2017 the authors. See the 'Copyright and license' section of the
+<!-- Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 README.md file at the top-level directory of this repository.
 
 Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -15,3 +15,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added this changelog
+
+### Changed
+- Switched from `*mut u8` to `NonNull<u8>` for pointer values

--- a/slab-alloc/CHANGELOG.md
+++ b/slab-alloc/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2017 the authors. See the 'Copyright and license' section of the
+<!-- Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 README.md file at the top-level directory of this repository.
 
 Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -15,6 +15,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added this changelog
+
+### Changed
+- Upgraded to new `ObjectAlloc` and `UntypedObjectAlloc` traits that use
+  `NonNull<u8>` instead of `*mut u8`
+- Switch from `*mut T` to `NonNull<T>` or `Option<NonNull<T>>` for various
+  internal pointers
+- Make `PtrHashMap` support any value type that is `Copy`, not just raw
+  pointers
 
 ### Fixed
 - Fixed a bug that prevented compilation on 32-bit Windows

--- a/slab-alloc/Cargo.toml
+++ b/slab-alloc/Cargo.toml
@@ -41,8 +41,8 @@ hashmap-no-coalesce = []
 [dependencies]
 interpolate_idents = "0.2.2"
 lazy_static = { version = "1.0.0", features = ["spin_no_std"] }
-mmap-alloc = "0.1.0"
-object-alloc = "0.1.0"
+mmap-alloc = { path = "../mmap-alloc" }
+object-alloc = { path = "../object-alloc" }
 object-alloc-test = { path = "../object-alloc-test" }
 rand = "0.3"
 sysconf = "0.3.1"

--- a/slab-alloc/travis.sh
+++ b/slab-alloc/travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -14,6 +14,8 @@ travis-cargo --only nightly build
 # Use opt-level=3 because the corruption tests take a long time, and the
 # optimized build saves more time in test execution than it adds in compilation
 # time.
+# TODO: Now that we have opt-level = 3 in the test profile in Cargo.toml,
+# is this necessary anymore?
 RUSTFLAGS='-C opt-level=3' RUST_BACKTRACE=1 travis-cargo --only nightly test
 # TODO: Once no-std and no-os work, add those features.
 for feature in build-ignored-tests use-stdlib-hashmap no-coloring hashmap-no-resize hashmap-no-coalesce; do


### PR DESCRIPTION
- Switch from `*mut u8` and `*mut T` to `NonNull<u8>` and `NonNull<T>` in trait methods
- Upgrade `slab-alloc`, `mmap-alloc`, and `object-alloc-test` accordingly
- Closes #140