### PR TITLE
mmap-alloc: Add large-align feature, support committing on Linux/Mac

### DIFF
--- a/mmap-alloc/CHANGELOG.md
+++ b/mmap-alloc/CHANGELOG.md
@@ -13,9 +13,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Added support for committing on Linux and Mac
+- Added support for configuring commit on allocation on Mac
+- Added support for alignments larger than a memory page (`large-align`
+  feature)
+
 ### Changed
 - Upgraded to new `UntypedObjectAlloc` trait that uses `NonNull<u8>` instead
   of `*mut u8`
+- Improved documentation on committed vs. uncommitted memory
 
 ## 0.2.0
 

--- a/mmap-alloc/Cargo.toml
+++ b/mmap-alloc/Cargo.toml
@@ -21,6 +21,11 @@ repository = "https://github.com/ezrosent/allocators-rs/tree/master/mmap-alloc"
 
 exclude = ["appveyor.sh", "travis.sh"]
 
+[features]
+# Support alignments larger than a page size by mapping a larger region
+# and then unmapping all but a properly-aligned subset of the region.
+large-align = []
+
 [dependencies]
 errno = "0.2"
 kernel32-sys = "0.2"

--- a/mmap-alloc/appveyor.sh
+++ b/mmap-alloc/appveyor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -17,4 +17,6 @@ fi
 export RUST_TEST_THREADS=1
 
 cargo build
-RUST_BACKTRACE=1 cargo test
+for feature in '' large-align; do
+  RUST_BACKTRACE=1 cargo test --features "$feature"
+done

--- a/mmap-alloc/travis.sh
+++ b/mmap-alloc/travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -17,4 +17,7 @@ travis-cargo --only nightly build
 # (e.g., see https://travis-ci.org/ezrosent/allocators-rs/jobs/291713981)
 # TODO: Remove -q and --verbose once the following issue is fixed:
 # https://github.com/huonw/travis-cargo/issues/75
-RUST_BACKTRACE=1 travis-cargo -q --only nightly test -- --verbose -- --skip test_map_panic_too_large
+for feature in '' large-align; do
+  RUST_BACKTRACE=1 travis-cargo -q --only nightly test -- --features "$feature" \
+    --verbose -- --skip test_map_panic_too_large  
+done


### PR DESCRIPTION
- Add `large-align` feature, allowing alignments larger than a page size
- Allow memory to be explicitly committed on Linux and Mac
- Allow memory to be committed on allocation on Mac
- Improve documentation around committed/uncommitted memory
- Closes #151