### PR TITLE
elfmalloc: Re-enable Travis tests, set RUST_TEST_THREADS=1

### DIFF
--- a/elfmalloc/Cargo.toml
+++ b/elfmalloc/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -38,6 +38,9 @@ local_cache = []
 use_default_allocator = []
 print_stats = []
 magazine_layer = []
+# Limit the amount of memory used by tests to avoid running out.
+# This is used primarily in Travis.
+low-memory-tests = []
 # Implement the C allocation API (malloc, free, etc) by implementing the
 # malloc-bind crate's Malloc trait. This feature will enable certain
 # optimizations that will make the C API faster but result in worse memory

--- a/elfmalloc/travis.sh
+++ b/elfmalloc/travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -10,13 +10,20 @@
 set -x
 set -e
 
-# Skip elfmalloc tests until we can get them working (still build so we can
-# detect compilation failures).
-travis-cargo --only nightly build
-exit 0
+# Since elfmalloc tests use a lot of memory, we use RUST_TEST_THREADS=1
+# to force them to run sequentially in order to reduce the total memory
+# consumption and avoid a crash on Travis.
 
 travis-cargo --only nightly build
-RUST_BACKTRACE=1 travis-cargo --only nightly test
-for feature in prime_schedules huge_segments no_lazy_region nightly; do
-  RUST_BACKTRACE=1 travis-cargo --only nightly test -- --features "$feature"
+RUST_TEST_THREADS=1 RUST_BACKTRACE=1 travis-cargo --only nightly test \
+  -- --features low-memory-tests
+for feature in    \
+  prime_schedules \
+  huge_segments   \
+  no_lazy_region  \
+  local_cache     \
+  magazine_layer  \
+  c-api; do
+  RUST_TEST_THREADS=1 RUST_BACKTRACE=1 travis-cargo --only nightly test \
+    -- --features "$feature low-memory-tests"
 done


### PR DESCRIPTION
We've previously had an issue with running out of memory during Travis tests, so this PR forces the tests to run sequentially to reduce the maximum working set size and reduces the size of certain tests when running in Travis via the `low-memory-tests` feature.