### PR TITLE
elfmalloc: Remove background cleanup thread

### DIFF
--- a/bagpipe/CHANGELOG.md
+++ b/bagpipe/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2017 the authors. See the 'Copyright and license' section of the
+<!-- Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 README.md file at the top-level directory of this repository.
 
 Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Bagpipes can now call drop on their elements when they are dropped. This does
   not happen automatically, but there is a new trait to inject cleanup callbacks
   to `BagPipe` shutdown.
+
+### Changed
+- Bagpipes now store a Crossbeam Epoch GC instance rather than using the global
+  singleton instance so that using a Bagpipe does not rely on thread-local
+  storage.
 
 ### Fixed
 - Fixed a bug where crossbeam TLS would remain uninitialized upon cloning a

--- a/bagpipe/Cargo.toml
+++ b/bagpipe/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -31,4 +31,5 @@ huge_segments = []
 
 [dependencies]
 crossbeam = "0.2"
+crossbeam-epoch = "0.4.0"
 num_cpus = "1.5"

--- a/bagpipe/src/bin/bench_bag.rs
+++ b/bagpipe/src/bin/bench_bag.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 // README.md file at the top-level directory of this repository.
 //
 // Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -52,7 +52,7 @@ fn enqueue_dequeue_pairs_usize<W>(npairs: usize,
                                   prefill_with: usize,
                                   description: String)
                                   -> WorkloadStats
-    where W: WeakBag<Item = usize> + Send + Sync + 'static + Default
+    where W: WeakBag<Item = usize> + Send + 'static + Default
 {
     let wb = W::default();
     for i in 0..prefill_with {
@@ -113,7 +113,7 @@ fn enqueue_dequeue_pairs_strong<W>(npairs: usize,
                                    prefill_with: usize,
                                    description: String)
                                    -> WorkloadStats
-    where W: WeakBag<Item = usize> + Send + Sync + 'static + Default
+    where W: WeakBag<Item = usize> + Send + 'static + Default
 {
     let wb = W::default();
     for i in 0..prefill_with {
@@ -168,7 +168,7 @@ fn producer_consumer_strong<W>(npairs: usize,
                                prefill_with: usize,
                                description: String)
                                -> WorkloadStats
-    where W: WeakBag<Item = usize> + Send + Sync + 'static + Default
+    where W: WeakBag<Item = usize> + Send + 'static + Default
 {
     let wb = W::default();
     for i in 0..prefill_with {
@@ -238,7 +238,7 @@ fn enqueue_dequeue_usize<W>(npairs: usize,
                             prefill_with: usize,
                             description: String)
                             -> WorkloadStats
-    where W: WeakBag<Item = usize> + Send + Sync + 'static + Default
+    where W: WeakBag<Item = usize> + Send + 'static + Default
 {
     let wb = W::default();
     for i in 0..prefill_with {

--- a/bsalloc/src/lib.rs
+++ b/bsalloc/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 // README.md file at the top-level directory of this repository.
 //
 // Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -10,6 +10,7 @@
 #![feature(alloc)]
 #![feature(global_allocator)]
 extern crate alloc;
+#[cfg(debug_assertions)]
 #[macro_use]
 extern crate alloc_fmt;
 #[macro_use]

--- a/elfc/Cargo.toml
+++ b/elfc/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2017 the authors. See the 'Copyright and license' section of the
+# Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 # README.md file at the top-level directory of this repository.
 #
 # Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -30,6 +30,7 @@ logging = ["elfmalloc/print_stats"]
 
 [dependencies]
 alloc-tls = { path = "../alloc-tls", features = ["dylib"] }
+bsalloc = { path = "../bsalloc" }
 elfmalloc = { path = "../elfmalloc", features = ["c-api"] }
 malloc-bind = { path = "../malloc-bind" }
 env_logger = "0.4.3"

--- a/elfc/src/lib.rs
+++ b/elfc/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 // README.md file at the top-level directory of this repository.
 //
 // Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -17,6 +17,10 @@
 
 #[cfg(feature = "logging")]
 extern crate alloc_tls;
+// Linking in `bsalloc` causes it to be used as the global heap allocator.
+// This is important because otherwise any allocation performed inside of
+// elfmalloc using the global allocator would be recursive.
+extern crate bsalloc;
 extern crate elfmalloc;
 #[cfg(feature = "logging")]
 extern crate env_logger;

--- a/elfmalloc/Cargo.toml
+++ b/elfmalloc/Cargo.toml
@@ -35,7 +35,6 @@ prime_schedules = ["bagpipe/prime_schedules"]
 huge_segments = ["bagpipe/huge_segments"]
 no_lazy_region = []
 local_cache = []
-use_default_allocator = []
 print_stats = []
 magazine_layer = []
 # Limit the amount of memory used by tests to avoid running out.
@@ -51,7 +50,6 @@ c-api = []
 alloc-fmt = { path = "../alloc-fmt" }
 alloc-tls = { path = "../alloc-tls" }
 bagpipe = { path = "../bagpipe" }
-bsalloc = "0.1.0"
 lazy_static = "1.0.0"
 libc = "0.2"
 log = "0.3.8"

--- a/elfmalloc/src/general.rs
+++ b/elfmalloc/src/general.rs
@@ -67,17 +67,6 @@ pub(crate) mod global {
     //! (TLS) to store handles to this global instance. While this is essentially the architecture
     //! we use, a number of hacks have been added to ensure correctness.
     //!
-    //! ## TLS Destructors
-    //!
-    //! Thread-local handles are stored in TLS. In their destructors, they potentially call into
-    //! crossbeam code. This code too requires the use of TLS. We are not guaranteed any order in
-    //! which these destructors can be run, and we have observed that crossbeam's can be run before
-    //! ours, resulting in a panic.
-    //!
-    //! To avoid this we spawn a background thread that services `free` operations sent from
-    //! threads in circumstances like this. While this is undoubtedly a code smell, it may be used
-    //! in the future to collect statistics regarding the running allocator.
-    //!
     //! ## Recursive `malloc` calls
     //!
     //! When used as a standard `malloc` implementation through the `elfc` crate via `LD_PRELOAD`,
@@ -85,9 +74,10 @@ pub(crate) mod global {
     //! problem is that the code that enqueues destructors for pthread TSD calls `calloc`; this
     //! causes all such calls to stack overflow.
     //!
-    //! The fix for this is to use the thread-local attribute to create a thread-local boolean that
-    //! indicates if the current thread's value has been initialized. If this value is false, a
-    //! slower fallback algorithm is used.
+    //! In order to avoid thisi problem, we use the `alloc-tls` crate, which can detect this
+    //! recursion. When such recursion is detected, we fall back on a slow path of creating a new
+    //! one-time-use instance of the value that is normally stored in thread-local storage in
+    //! order to perform the operation and then discard it.
     #[allow(unused_imports)]
     use super::{CoarseAllocator, DynamicAllocator, DirtyFn, ElfMalloc, MemorySource, ObjectAlloc,
                 PageAlloc, TieredSizeClasses, TypedArray, AllocType, get_type, Source, AllocMap};
@@ -101,10 +91,6 @@ pub(crate) mod global {
     use std::thread;
 
     type PA = PageAlloc<Source, ()>;
-    // For debugging purposes: run a callback to eagerly dirty several pages. This is generally bad
-    // for performance.
-    //
-    // type PA = PageAlloc<Source, BackgroundDirty>;
 
     unsafe fn dirty_slag(mem: *mut u8) {
         trace!("dirtying {:?}", mem);
@@ -117,26 +103,13 @@ pub(crate) mod global {
         }
     }
 
-    #[derive(Clone)]
-    struct BackgroundDirty;
-    impl DirtyFn for BackgroundDirty {
-        fn dirty(_mem: *mut u8) {
-            let _ = unsafe { LOCAL_DESTRUCTOR_CHAN.with(|h| h.send(Husk::Slag(_mem))).unwrap() };
-        }
-    }
-
-    #[derive(Clone)]
     /// A wrapper like `DynamicAllocator` in the parent module.
     ///
     /// The reason we have a wrapper is for this module's custom `Drop` implementation, mentioned
     /// in the module documentation.
+    #[derive(Clone)]
     struct GlobalAllocator {
-        // GlobalAllocator's Drop implementation reads this field (using ptr::read) and sends it
-        // over a channel. This invalidates the underlying memory, but of course Rust doesn't know
-        // that, so if this field were of the type ElfMalloc<...>, the field's drop method would be
-        // run after GlobalAllocator's drop method returned. We use ManuallyDrop to prevent that
-        // from happening.
-        alloc: ManuallyDrop<ElfMalloc<PA, TieredSizeClasses<ObjectAlloc<PA>>>>,
+        alloc: ElfMalloc<PA, TieredSizeClasses<ObjectAlloc<PA>>>,
         // In some rare cases, we've observed that a thread-local GlobalAllocator is spuriously
         // dropped twice. Until we figure out why and fix it, we just detect when it's happening
         // and make the second drop call a no-op.
@@ -161,51 +134,20 @@ pub(crate) mod global {
         }
     }
 
-    /// The type for messages sent to the background thread. These can either be arrays of size
-    /// classes to be cleaned up (in the case of thread destruction) or pointers to be freed (in
-    /// the case of a recursive call to `free`).
-    enum Husk {
-        Array(ElfMalloc<PA, TieredSizeClasses<ObjectAlloc<PA>>>),
-        #[allow(dead_code)]
-        Ptr(*mut u8),
-        #[allow(dead_code)]
-        Slag(*mut u8),
-    }
-
-    unsafe impl Send for Husk {}
-
     impl Drop for GlobalAllocator {
         fn drop(&mut self) {
-            unsafe fn with_chan<F: FnMut(&Sender<Husk>)>(mut f: F) {
-                LOCAL_DESTRUCTOR_CHAN
-                    .with(|chan| f(chan))
-                    .unwrap_or_else(|| {
-                        let chan = DESTRUCTOR_CHAN.lock().unwrap().clone();
-                        f(&chan);
-                    })
-            }
-
             // XXX: Why this check?
             //
             // We have found that for some reason, this destructor can be called more than once on
             // the same value. This could be a peculiarity of the TLS implementation, or it could
             // be a bug in the code here. Regardless; without this check there are some cases in
             // which this benchmark drops Arc-backed data-structures multiple times, leading to
-            // segfaults either here or in the background thread.
+            // segfaults.
             if self.dropped {
                 alloc_eprintln!("{:?} dropped twice!", self as *const _);
                 return;
             }
-            unsafe {
-                with_chan(|chan| {
-                    // After we read the alloc field with ptr::read, the underlying memory should
-                    // be treated as uninitialized, but Rust doesn't know this. We use ManuallyDrop
-                    // to ensure that Rust doesn't try to drop the field after this method returns.
-                    let dyn = ManuallyDrop::into_inner(ptr::read(&self.alloc));
-                    let _ = chan.send(Husk::Array(dyn));
-                });
-                self.dropped = true;
-            };
+            self.dropped = true;
         }
     }
 
@@ -234,7 +176,7 @@ pub(crate) mod global {
 
     fn new_handle() -> GlobalAllocator {
         GlobalAllocator {
-            alloc: ManuallyDrop::new(ELF_HEAP.inner.as_ref().expect("heap uninitialized").clone()),
+            alloc: ELF_HEAP.inner.as_ref().expect("heap uninitialized").clone(),
             dropped: false,
         }
     }
@@ -245,33 +187,7 @@ pub(crate) mod global {
         }
     }
 
-    lazy_static! {
-        static ref ELF_HEAP: GlobalAllocProvider = GlobalAllocProvider::new();
-        static ref DESTRUCTOR_CHAN: Mutex<Sender<Husk>> = {
-            // Background thread code: block on a channel waiting for memory reclamation messages
-            // (Husks).
-            let (sender, receiver) = channel();
-            thread::spawn(move || unsafe {
-                let mut local_alloc = new_handle();
-                loop {
-                    if let Ok(msg) = receiver.recv() {
-                        let msg: Husk = msg;
-                        match msg {
-                            Husk::Array(alloc) => mem::drop(DynamicAllocator(alloc)),
-                            Husk::Ptr(p) => local_alloc.alloc.free(p),
-                            Husk::Slag(s) => dirty_slag(s),
-                        }
-                        continue
-                    }
-                    mem::forget(local_alloc);
-                    return;
-                }
-            });
-            Mutex::new(sender)
-        };
-    }
-
-    alloc_thread_local!{ static LOCAL_DESTRUCTOR_CHAN: Sender<Husk> = DESTRUCTOR_CHAN.lock().unwrap().clone(); }
+    lazy_static! { static ref ELF_HEAP: GlobalAllocProvider = GlobalAllocProvider::new(); }
     alloc_thread_local!{ static LOCAL_ELF_HEAP: UnsafeCell<GlobalAllocator> = UnsafeCell::new(new_handle()); }
 
     fn with_local_or_clone<F, R>(f: F) -> R
@@ -297,16 +213,7 @@ pub(crate) mod global {
     }
 
     pub unsafe fn free(item: *mut u8) {
-        alloc_tls_fast_with!(LOCAL_ELF_HEAP, h, { (*h.get()).alloc.free(item) })
-            .unwrap_or_else(|| match get_type(item) {
-                AllocType::Large => {
-                    super::large_alloc::free(item);
-                }
-                AllocType::SmallSlag | AllocType::BigSlag => {
-                    let chan = DESTRUCTOR_CHAN.lock().unwrap().clone();
-                    let _ = chan.send(Husk::Ptr(item));
-                }
-            });
+        with_local_or_clone(|h| (*h.get()).alloc.free(item));
     }
 }
 
@@ -924,7 +831,7 @@ mod large_alloc {
     use super::super::alloc_type::AllocType;
 
     // For debugging, we keep around a thread-local map of pointers to lengths. This helps us
-    // scrutinize if various header data is getting propagated correctly.
+    // scrutinize whether various header data is getting propagated correctly.
     #[cfg(test)]
     thread_local! {
         pub static SEEN_PTRS: RefCell<HashMap<*mut u8, usize>> = RefCell::new(HashMap::new());

--- a/elfmalloc/src/lib.rs
+++ b/elfmalloc/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 the authors. See the 'Copyright and license' section of the
+// Copyright 2017-2018 the authors. See the 'Copyright and license' section of the
 // README.md file at the top-level directory of this repository.
 //
 // Licensed under the Apache License, Version 2.0 (the LICENSE-APACHE file) or
@@ -21,11 +21,6 @@ extern crate num_cpus;
 
 #[macro_use]
 extern crate alloc_fmt;
-// Linking in `bsalloc` causes it to be used as the global heap allocator. That is important when
-// using this as a basis for a `malloc` library, but it becomes a hindrance when using this crate
-// as a specialized allocator library.
-#[cfg(not(feature = "use_default_allocator"))]
-extern crate bsalloc;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]


### PR DESCRIPTION
Now that bagpipes don't rely on TLS, we can safely clean up thread-local caches while they are being dropped rather than sending pointers to a dedicated background thread.