### PR TITLE
mmap-alloc: Update to new Alloc trait

### DIFF
--- a/mmap-alloc/CHANGELOG.md
+++ b/mmap-alloc/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   feature)
 
 ### Changed
+- Upgraded to new `Alloc` trait that uses `Result<NonNull<u8>, AllocErr>`
+  instead of `Result<*mut u8, AllocErr>`
 - Upgraded to new `UntypedObjectAlloc` trait that uses `Option<NonNull<u8>>`
   instead of `Result<*mut u8, Exhausted>`
 - Improved documentation on committed vs. uncommitted memory


### PR DESCRIPTION
This PR supersedes #181 (it contains the same commit as #181, plus a new one to handle further changes to the `Alloc` trait which landed after that PR was posted).

@fitzgen heads up about this since it affects wee_alloc.