### PR TITLE
Upgrade stdlib dependencies

### DIFF
--- a/alloc-tls/src/lib.rs
+++ b/alloc-tls/src/lib.rs
@@ -12,8 +12,6 @@
 
 #![feature(allow_internal_unsafe)]
 #![feature(const_fn)]
-#![feature(const_ptr_null_mut)]
-#![feature(const_unsafe_cell_new)]
 #![feature(core_intrinsics)]
 #![feature(test)]
 #![feature(thread_local)]

--- a/elfmalloc/Cargo.toml
+++ b/elfmalloc/Cargo.toml
@@ -51,7 +51,7 @@ c-api = []
 alloc-fmt = { path = "../alloc-fmt" }
 alloc-tls = { path = "../alloc-tls" }
 bagpipe = { path = "../bagpipe" }
-bsalloc = "0.1.0"
+bsalloc = { path = "../bsalloc" }
 lazy_static = "1.0.0"
 libc = "0.2"
 log = "0.3.8"

--- a/elfmalloc/src/alloc_impl.rs
+++ b/elfmalloc/src/alloc_impl.rs
@@ -18,7 +18,7 @@ extern crate alloc;
 extern crate malloc_bind;
 #[cfg(feature = "c-api")]
 extern crate libc;
-use self::alloc::allocator::{Alloc, AllocErr, Layout};
+use self::alloc::alloc::{Alloc, AllocErr, Layout};
 #[cfg(feature = "c-api")]
 use self::malloc_bind::{LayoutFinder, Malloc, MIN_ALIGN};
 use super::general::global;

--- a/elfmalloc/src/rust_alloc.rs
+++ b/elfmalloc/src/rust_alloc.rs
@@ -73,7 +73,7 @@
 //! specially: in the other system, they would need their own `Creek`.
 extern crate num_cpus;
 
-use super::alloc::allocator::{Alloc, AllocErr, Layout};
+use super::alloc::alloc::{Alloc, AllocErr, Layout};
 use super::general::{Multiples, PowersOfTwo, ObjectAlloc, MULTIPLE, AllocMap};
 use super::slag::{PageAlloc, Metadata, RevocablePipe, compute_metadata, SlagPipe, PageCleanup};
 #[allow(unused_imports)]

--- a/elfmalloc/src/sources.rs
+++ b/elfmalloc/src/sources.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicUsize, AtomicPtr, Ordering};
 use std::mem;
 use super::utils::{likely, mmap};
 
-use alloc::allocator::{Alloc, Layout};
+use alloc::alloc::{Alloc, Layout};
 use mmap_alloc::MapAlloc;
 
 /// A generator of chunks of memory providing an `sbrk`-like interface.

--- a/elfmalloc/src/utils.rs
+++ b/elfmalloc/src/utils.rs
@@ -12,7 +12,7 @@ use std::cell::UnsafeCell;
 
 pub mod mmap {
     use mmap_alloc::{MapAlloc, MapAllocBuilder};
-    use alloc::allocator::{Alloc, Layout};
+    use alloc::alloc::{Alloc, Layout};
 
     lazy_static!{ 
         static ref MMAP: MapAlloc = MapAllocBuilder::default()

--- a/elfmalloc/src/vec_alloc.rs
+++ b/elfmalloc/src/vec_alloc.rs
@@ -13,7 +13,7 @@
 
 extern crate smallvec;
 use self::smallvec::VecLike;
-use super::alloc::allocator::Alloc;
+use super::alloc::alloc::Alloc;
 use super::alloc::heap::Heap;
 use super::alloc::raw_vec::RawVec;
 use super::rust_alloc;

--- a/malloc-bind/src/lib.rs
+++ b/malloc-bind/src/lib.rs
@@ -31,7 +31,6 @@
 #![feature(alloc)]
 #![feature(core_intrinsics)]
 #![feature(const_fn)]
-#![feature(const_size_of)]
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("malloc-bind only supports Linux, and Mac, and Windows");

--- a/mmap-alloc/src/lib.rs
+++ b/mmap-alloc/src/lib.rs
@@ -37,7 +37,7 @@ extern crate kernel32;
 #[cfg(windows)]
 extern crate winapi;
 
-use self::alloc::allocator::{Alloc, AllocErr, CannotReallocInPlace, Excess, Layout};
+use self::alloc::alloc::{Alloc, AllocErr, CannotReallocInPlace, Excess, Layout};
 use self::object_alloc::UntypedObjectAlloc;
 use core::ptr::{self, NonNull};
 

--- a/object-alloc-test/src/lib.rs
+++ b/object-alloc-test/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(test)]
 #![feature(const_fn)]
 #![feature(const_size_of)]
-#![feature(nonnull_cast)]
 #![feature(plugin)]
 #![plugin(interpolate_idents)]
 

--- a/object-alloc/src/lib.rs
+++ b/object-alloc/src/lib.rs
@@ -8,10 +8,9 @@
 #![no_std]
 #![feature(alloc, allocator_api)]
 #![feature(core_intrinsics)]
-#![feature(nonnull_cast)]
 
 extern crate alloc;
-use alloc::allocator::Layout;
+use alloc::alloc::Layout;
 use core::intrinsics::abort;
 use core::ptr::NonNull;
 

--- a/slab-alloc/src/backing.rs
+++ b/slab-alloc/src/backing.rs
@@ -107,7 +107,7 @@ pub mod mmap {
     extern crate alloc;
     extern crate mmap_alloc;
     extern crate sysconf;
-    use self::alloc::allocator::Layout;
+    use self::alloc::alloc::Layout;
     #[cfg(target_os = "linux")]
     use self::mmap_alloc::MapAlloc;
     #[cfg(not(target_os = "linux"))]

--- a/slab-alloc/src/lib.rs
+++ b/slab-alloc/src/lib.rs
@@ -51,7 +51,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(alloc, allocator_api)]
-#![feature(nonnull_cast)]
 #![feature(plugin)]
 #![cfg_attr(test, feature(test))]
 #![plugin(interpolate_idents)]
@@ -79,7 +78,7 @@ extern crate sysconf;
 #[cfg(test)]
 extern crate test;
 
-use self::alloc::allocator::Layout;
+use self::alloc::alloc::Layout;
 use self::init::InitSystem;
 use self::object_alloc::{ObjectAlloc, UntypedObjectAlloc};
 use self::util::list::*;

--- a/slab-alloc/src/util.rs
+++ b/slab-alloc/src/util.rs
@@ -69,7 +69,7 @@ pub mod stack {
         /// given size (in bytes) and the data used for a stack. The object must be aligned to at
         /// least the same alignment as T, or else the value returned may be incorrect.
         pub fn padding_after(size: usize) -> usize {
-            use self::alloc::allocator::Layout;
+            use self::alloc::alloc::Layout;
             // NOTE: The Layout alignment isn't used here, so we use 1 because it's guaranteed not
             // to cause from_size_align to return None.
             Layout::from_size_align(size, 1)
@@ -488,7 +488,7 @@ pub mod workingset {
 
 pub mod misc {
     extern crate alloc;
-    use self::alloc::allocator::Layout;
+    use self::alloc::alloc::Layout;
 
     pub fn satisfy_min_align(layout: Layout, min_align: usize) -> Layout {
         if min_align <= layout.align() {


### PR DESCRIPTION
- Update from `alloc::allocator` to `alloc::alloc` module
- Remove stabilized or unrecognized features